### PR TITLE
Add ability to have automated Docker builds

### DIFF
--- a/.dockerfiles/6.1/Dockerfile
+++ b/.dockerfiles/6.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+MAINTAINER https://github.com/SatelliteQE
+
+RUN git clone https://github.com/SatelliteQE/satellite-populate.git && \
+  cd satellite-populate && python3 setup.py install
+RUN pip install -e git+https://github.com/SatelliteQE/nailgun.git@0.28.0#egg=nailgun
+
+ENV HOME /root/satellite-populate
+WORKDIR /root/satellite-populate
+
+EXPOSE 22
+
+ENTRYPOINT ["satellite-populate"]

--- a/.dockerfiles/6.2/Dockerfile
+++ b/.dockerfiles/6.2/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+MAINTAINER https://github.com/SatelliteQE
+
+RUN git clone https://github.com/SatelliteQE/satellite-populate.git && \
+  cd satellite-populate && python3 setup.py install
+RUN pip install -e git+https://github.com/SatelliteQE/nailgun.git@6.2.z#egg=nailgun
+
+ENV HOME /root/satellite-populate
+WORKDIR /root/satellite-populate
+
+EXPOSE 22
+
+ENTRYPOINT ["satellite-populate"]

--- a/.dockerfiles/6.3/Dockerfile
+++ b/.dockerfiles/6.3/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+MAINTAINER https://github.com/SatelliteQE
+
+RUN git clone https://github.com/SatelliteQE/satellite-populate.git && \
+  cd satellite-populate && python3 setup.py install
+RUN pip install -e git+https://github.com/SatelliteQE/nailgun.git#egg=nailgun
+
+ENV HOME /root/satellite-populate
+WORKDIR /root/satellite-populate
+
+EXPOSE 22
+
+ENTRYPOINT ["satellite-populate"]


### PR DESCRIPTION
With docker, we can more easily manage nailgun versions, as well as
any version control we want to have with satellite-populate.
Fixes #11 
